### PR TITLE
Correctly return error when mounting fails and mountpoint not found

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.so
 *.dylib
 etcd3-bootstrap-linux-amd64
+etcd3-bootstrap-linux-amd64-*
 
 # Test binary, build with `go test -c`
 *.test

--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,18 @@
 
 SHELL := /bin/bash
 S3_BUCKET := "monzo-deployment-artifacts"
+VERSION := "v1.0.1"
 
-.DEFAULT_GOAL: etcd3-bootstrap-linux-amd64
+.DEFAULT_GOAL: etcd3-bootstrap-linux-amd64-$(VERSION)
 
-etcd3-bootstrap-linux-amd64: vendor/ *.go
-	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o etcd3-bootstrap-linux-amd64 -ldflags '-s'
+etcd3-bootstrap-linux-amd64-$(VERSION): vendor/ *.go
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o etcd3-bootstrap-linux-amd64-$(VERSION) -ldflags '-s'
 
 .PHONY: upload-s3
-upload-s3: etcd3-bootstrap-linux-amd64
+upload-s3: etcd3-bootstrap-linux-amd64-$(VERSION)
 	@if ! git diff HEAD --exit-code &> /dev/null; \
 	then \
 		echo -e "Unexpected dirty working directory; commit your changes"; \
 		exit 1; \
 	fi
-	aws s3 cp ./etcd3-bootstrap-linux-amd64 "s3://$(S3_BUCKET)/etcd3-bootstrap-linux-amd64/etcd3-bootstrap-linux-amd64"
+	aws s3 cp ./etcd3-bootstrap-linux-amd64-$(VERSION) "s3://$(S3_BUCKET)/etcd3-bootstrap-linux-amd64/etcd3-bootstrap-linux-amd64-$(VERSION)"

--- a/ebs.go
+++ b/ebs.go
@@ -157,7 +157,7 @@ func ensureVolumeMounted(blockDevice, mountPoint string) error {
 		return nil
 	}
 
-	return errors.Wrap(err, "cannot mount or verify mount. cowardly refusing to continue")
+	return errors.New("cannot mount or verify mount. cowardly refusing to continue")
 }
 
 func ensureVolumeWriteable(mountPoint string) error {


### PR DESCRIPTION
If mounting the drive fails, we should fail and bail out returning an error exit status.

In `ensureVolumeMounted` we compare the output of the `mount` command to make sure the drive is already mounted and return an error if it's nil, however [on these lines](https://github.com/monzo/etcd3-bootstrap/blob/master/ebs.go#L149-L160) we end up with `err` set to nil, since the `mount` command succeeded, but we didn't find the output we expected.

In `pkg/errors`, if you pass a `nil` `err` to `errors.Wrap`, it returns nil. This mean that if the mount failed, we were actually just continuing with creating the directory and setting the permissions instead of bailing out. Instead we should return an `errors.New` so we always return a non-nil error.

Additionally add a version suffix to the built and uploaded binaries.

[Context / Investigation](https://monzo.slack.com/archives/C02BESD9AP9/p1737474444237429?thread_ts=1737472248.162859&cid=C02BESD9AP9)