### PR TITLE
Fix handling of flags passed to mkfs.ext4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 
 SHELL := /bin/bash
 S3_BUCKET := "monzo-deployment-artifacts"
-VERSION := "v1.0.1"
+VERSION := "v1.0.2"
 
 .DEFAULT_GOAL: etcd3-bootstrap-linux-amd64-$(VERSION)
 

--- a/ebs.go
+++ b/ebs.go
@@ -119,7 +119,12 @@ func ensureVolumeInited(blockDevice, fileSystemFormatType, fileSystemFormatArgum
 	log.Println("Filesystem not present")
 
 	// format volume here
-	cmd := exec.Command("sudo", "/usr/sbin/mkfs."+fileSystemFormatType, blockDevice, fileSystemFormatArguments)
+	mkfsCmd := []string{"/usr/sbin/mkfs." + fileSystemFormatType, blockDevice}
+	if fileSystemFormatArguments != "" {
+		mkfsCmd = append(mkfsCmd, fileSystemFormatArguments)
+	}
+
+	cmd := exec.Command("sudo", mkfsCmd...)
 	cmd.Stdout, cmd.Stderr = os.Stdout, os.Stderr
 	if err := cmd.Run(); err != nil {
 		return errors.Wrap(err, "mkfs."+fileSystemFormatType+" failed")

--- a/ebs.go
+++ b/ebs.go
@@ -119,7 +119,7 @@ func ensureVolumeInited(blockDevice, fileSystemFormatType, fileSystemFormatArgum
 	log.Println("Filesystem not present")
 
 	// format volume here
-	mkfsCmd := []string{"/usr/sbin/mkfs." + fileSystemFormatType, blockDevice}
+	mkfsCmd := []string{"/usr/sbin/mkfs", "-t", fileSystemFormatType, blockDevice}
 	if fileSystemFormatArguments != "" {
 		mkfsCmd = append(mkfsCmd, fileSystemFormatArguments)
 	}


### PR DESCRIPTION
We pass through the `-filesystem-arguments` flag directly to `exec.Command` as an argument. By default this is an empty string. Since we're execing the command directly instead of using shell this results in us passing an empty argument, which `mkfs.ext4` chokes on.

```
etcd3-bootstrap[2975]: mkfs.ext4: invalid blocks '' on device '/dev/xvdf'
etcd3-bootstrap[2975]: panic: mkfs.ext4 failed: exit status 1
```

Instead, construct the command as a string slice and passing it to `exec.Command` as variadic arguments.